### PR TITLE
Add as a module in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,8 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
+    _ = b.addModule("zig-datetime", .{ .source_file = .{ .path = "src/main.zig" } });
+
     const lib = b.addStaticLibrary(.{
         .name = "zig-datetime",
         // In this case the main source file is merely a path, however, in more


### PR DESCRIPTION
This will allow `zig-datetime` to be used with the experimental zig package manager.