### PR TITLE
fix error: invalid builtin function: '@abs'

### DIFF
--- a/src/datetime.zig
+++ b/src/datetime.zig
@@ -842,7 +842,7 @@ pub const Time = struct {
     // Create Time from a UTC Timestamp in milliseconds
     pub fn fromTimestamp(timestamp: i64) Time {
         const remainder = @mod(timestamp, time.ms_per_day);
-        var t: u64 = @abs(remainder);
+        var t: u64 = std.math.absCast(remainder);
         // t is now only the time part of the day
         const h: u32 = @intCast(@divFloor(t, time.ms_per_hour));
         t -= h * time.ms_per_hour;
@@ -1176,7 +1176,7 @@ pub const Datetime = struct {
     // From POSIX timestamp in milliseconds relative to 1 Jan 1970
     pub fn fromTimestamp(timestamp: i64) Datetime {
         const t = @divFloor(timestamp, time.ms_per_day);
-        const d: u64 = @abs(t);
+        const d: u64 = std.math.absCast(t);
         const days = if (timestamp >= 0) d + EPOCH else EPOCH - d;
         assert(days >= 0 and days <= MAX_ORDINAL);
         return Datetime{
@@ -1396,7 +1396,7 @@ pub const Datetime = struct {
         if (self.zone.offset < 0) {
             sign = '-';
         }
-        const offset = @abs(self.zone.offset);
+        const offset = std.math.absCast(self.zone.offset);
 
         var micro_part_len: u3 = 0;
         var micro_part: [7]u8 = undefined;
@@ -1428,7 +1428,7 @@ pub const Datetime = struct {
         if (self.zone.offset < 0) {
             sign = '-';
         }
-        const offset = @abs(self.zone.offset);
+        const offset = std.math.absCast(self.zone.offset);
 
         var micro_part_len: usize = 0;
         var micro_part: [7]u8 = undefined;


### PR DESCRIPTION
Fix the following error message
```
Build Summary: 0/5 steps succeeded; 1 failed (disable with --summary none)
run transitive failure
└─ run zigdemo transitive failure
   ├─ zig build-exe zigdemo Debug native 4 errors
   └─ install transitive failure
      └─ install zigdemo transitive failure
         └─ zig build-exe zigdemo Debug native (reused)
.zigmod/deps/v/git/github.com/frmdstryr/zig-datetime/branch-master/src/datetime.zig:845:22: error: invalid builtin function: '@abs'
        var t: u64 = @abs(remainder);
                     ^~~~~~~~~~~~~~~
.zigmod/deps/v/git/github.com/frmdstryr/zig-datetime/branch-master/src/datetime.zig:1179:24: error: invalid builtin function: '@abs'
        const d: u64 = @abs(t);
                       ^~~~~~~
.zigmod/deps/v/git/github.com/frmdstryr/zig-datetime/branch-master/src/datetime.zig:1399:24: error: invalid builtin function: '@abs'
        const offset = @abs(self.zone.offset);
                       ^~~~~~~~~~~~~~~~~~~~~~
.zigmod/deps/v/git/github.com/frmdstryr/zig-datetime/branch-master/src/datetime.zig:1431:24: error: invalid builtin function: '@abs'
        const offset = @abs(self.zone.offset);
                       ^~~~~~~~~~~~~~~~~~~~~~
```