### PR TITLE
Use GMT time zone for HTTP formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 zig-cache/
+.zig-cache/
 zig-out/
 
 .kdev4/

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 [![actions](https://github.com/frmdstryr/zig-datetime/actions/workflows/ci.yml/badge.svg)](https://github.com/frmdstryr/zig-datetime/actions)
 [![codecov](https://codecov.io/gh/frmdstryr/zig-datetime/branch/master/graph/badge.svg)](https://codecov.io/gh/frmdstryr/zig-datetime)
 
-
 A datetime module for Zig with an api similar to python's Arrow.
 
 > NOTE: This does not implement DST.
-
 
 ```zig
 
@@ -18,12 +16,12 @@ assert(next_year.year == 2020);
 assert(next_year.month == 1);
 assert(next_year.day == 1);
 
-// In UTC
+// In GMT
 const now = Datetime.now();
 const now_str = try now.formatHttp(allocator);
 defer allocator.free(now_str);
 std.debug.warn("The time is now: {}\n", .{now_str});
-// The time is now: Fri, 20 Dec 2019 22:03:02 UTC
+// The time is now: Sun, 19 Jan 2025 06:09:35 GMT
 
 
 ```

--- a/src/datetime.zig
+++ b/src/datetime.zig
@@ -1360,7 +1360,7 @@ pub const Datetime = struct {
             self.time.hour,
             self.time.minute,
             self.time.second,
-            self.zone.name, // TODO: Should be GMT
+            timezones.GMT.name,
         });
     }
 
@@ -1373,7 +1373,7 @@ pub const Datetime = struct {
             self.time.hour,
             self.time.minute,
             self.time.second,
-            self.zone.name, // TODO: Should be GMT
+            timezones.GMT.name,
         });
     }
 
@@ -1664,12 +1664,12 @@ test "readme-example" {
     assert(next_year.month == 1);
     assert(next_year.day == 1);
 
-    // In UTC
+    // In GMT
     const now = Datetime.now();
     const now_str = try now.formatHttp(allocator);
     defer allocator.free(now_str);
     std.log.warn("The time is now: {s}\n", .{now_str});
-    // The time is now: Fri, 20 Dec 2019 22:03:02 UTC
+    // The time is now: Sun, 19 Jan 2025 06:09:35 GMT
 
 }
 


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc822#section-5.2

> Time zone may be indicated in several ways.  "UT" is Univer-
     sal  Time  (formerly called "Greenwich Mean Time"); "GMT" is per-
     mitted as a reference to Universal Time.

Output from `zig build test`:

```
test
└─ run test stderr
[default] (warn): Modtime: Sun, 19 Jan 2025 06:13:12 GMT

[default] (warn): The time is now: Sun, 19 Jan 2025 06:30:03 GMT
```