### PR TITLE
chore: update to latest zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zig-datetime", .{ .root_source_file = b.path("src/main.zig") });
+    _ = b.addModule("datetime", .{ .root_source_file = b.path("src/main.zig") });
 
     const lib = b.addStaticLibrary(.{
         .name = "zig-datetime",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zig-datetime",
+    .name = .datetime,
     .version = "0.8.0",
+    .fingerprint = 0x93f3c6cacc579370, // Changing this has security and trust implications.
 
     .paths = .{
         "src",


### PR DESCRIPTION
see  ziglang/zig#22994.

I am not sure about changing the package's default name, but the main motivation is ...

https://github.com/ziglang/zig/blob/master/doc/build.zig.zon.md
"
It is redundant to include "zig" in this name because it is already within the Zig package namespace.

Must be a valid bare Zig identifier (don't @ me), limited to 32 bytes.
"